### PR TITLE
fix: [file-input] remove styles from regular input

### DIFF
--- a/src/components/atoms/InputFile/InputFile.tsx
+++ b/src/components/atoms/InputFile/InputFile.tsx
@@ -145,7 +145,7 @@ const InputFile: React.FC<IFileInputProps> = ({
 
   return (
     <div className='file-input__wrapper'>
-      <label className={ `rf-input ${className || ''}` }>
+      <label className={ `${className || ''}` }>
         <input
           ref={ ref }
           type='file'


### PR DESCRIPTION
Исправлены стили компонента `FileInput`.